### PR TITLE
Added condition for 'display' property

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -8,11 +8,15 @@ window.Echo = (function (window, document, undefined) {
     var coords = img.getBoundingClientRect();
     return (coords.top >= 0 && coords.left >= 0 && coords.top) <= (window.innerHeight || document.documentElement.clientHeight);
   };
+  
+  var _getStyle = function(el, prop) {
+    return window.getComputedStyle ? window.getComputedStyle(el, null).getPropertyValue(prop) : el.currentStyle[prop];
+  };
 
   var _pollImages = function () {
     for (var i = 0; i < store.length; i++) {
       var self = store[i];
-      if (_inView(self)) {
+      if (_inView(self) && (_getStyle(self, 'display') !== 'none' && _getStyle(self.parentNode, 'display') !== 'none')) {
         self.src = self.getAttribute('data-echo');
         if ([].indexOf && [].slice.call(store).indexOf(self) !== -1) {
           [].slice.call(store).splice(i, 1);


### PR DESCRIPTION
Check the CSS 'display' property on either the parent element or the image itself. If 'display' does not equal 'none', download the image.
