### PR TITLE
Listen to window scroll in a scalable way

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -24,11 +24,26 @@ window.Echo = (function (window, document, undefined) {
   var init = function () {
     store = document.querySelectorAll('[data-echo]');
     _pollImages();
-    window.onscroll = _pollImages;
+    _addEventListener(window, 'scroll', _pollImages);
   };
 
   return {
     init: init
+  };
+  
+  var _addEventListener = function(element, event, callback) {
+    if (element.addEventListener) {
+      _addEventListener = function(element, event, callback) {
+        element.addEventListener(event, callback, false);
+      };
+    }
+    else {
+      _addEventListener = function(element, event, callback) {
+        element.attachEvent('on' + event, callback);
+      };
+    }
+    
+    _addEventListener(element, event, callback);
   };
 
 })(window, document);


### PR DESCRIPTION
Directly writing to window.onscroll will break any other code run before this that writes to that location and will be broken by any other code that runs after this that writes to that location. Replacing with addEventListener (shimmed for IE8) so that N listeners can be on window.onscroll
