### PR TITLE
Fix Image Removal

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -2,7 +2,7 @@ window.Echo = (function (window, document, undefined) {
 
   'use strict';
 
-  var store;
+  var store = [];
 
   var _inView = function (img) {
     var coords = img.getBoundingClientRect();
@@ -19,7 +19,9 @@ window.Echo = (function (window, document, undefined) {
   };
 
   var init = function () {
-    store = Array.prototype.slice.call(document.querySelectorAll('[data-echo]'));
+    var nodes = document.querySelectorAll('[data-echo]');
+    for (var i = nodes.length; i--; store.unshift(nodes[i]));
+
     _pollImages();
     window.onscroll = _pollImages;
   };


### PR DESCRIPTION
`[].slice.call(foo)` returns an array that is a copy of the array-like `foo`, so when you splice it in this code, you're splicing (and then throwing away) a copy of store. I have edited the code to go ahead and slice the nodeList straight off (which saves cycles _and_ code) and then do the splicing on that directly, so your elements actually do get removed.

Also, every time you splice an element out, all of the elements in the array after it get renumbered, so the next iteration ends up skipping an element. An easy remedy to this is to run the loop in reverse, so only previously-iterated elements get renumbered. This also removes the need to check indexOf, as the element in question will never be out of bounds.
