### PR TITLE
Prevent processing same image twice that caused image flickr.

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -38,8 +38,10 @@ window.Echo = (function (window, document, undefined) {
 
     if (document.addEventListener) {
       window.addEventListener('scroll', _throttle, false);
+      window.addEventListener('resize', _throttle, false);
     } else {
       window.attachEvent('onscroll', _throttle);
+      window.attachEvent('onresize', _throttle);
     }
   };
 


### PR DESCRIPTION
In some use cases, Echo.init may be called more than once. Since it doesn't accept any selector to confine the scope of the images yet, I'm adding a data attribute to the image to prevent setting the src attribute more than once. I noticed at least in Chrome, setting the src attribute more than once in short intervals caused the images to flickr.
