### PR TITLE
Add window.onresize event handler.

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -38,8 +38,10 @@ window.Echo = (function (window, document, undefined) {
 
     if (document.addEventListener) {
       window.addEventListener('scroll', _throttle, false);
+      window.addEventListener('resize', _throttle, false);
     } else {
       window.attachEvent('onscroll', _throttle);
+      window.attachEvent('onresize', _throttle);
     }
   };
 


### PR DESCRIPTION
Window resize can cause previously folded images to be visible (e.g. increase the width or height of the browser window), the lazy loading handler should be attached to this event as well.
