### PR TITLE
Fix throttle behaviour

### DIFF
--- a/dist/echo.js
+++ b/dist/echo.js
@@ -12,7 +12,7 @@ window.Echo = (function (global, document, undefined) {
   /**
    * offset, throttle, poll vars
    */
-  var offset, throttle, poll;
+  var offset, throttle, poll, finalPoll;
 
   /**
    *  _inView
@@ -50,6 +50,10 @@ window.Echo = (function (global, document, undefined) {
       }
       clearTimeout(poll);
     }
+
+    poll = setTimeout(function(){
+        poll = null;
+      }, throttle);
   };
 
   /**
@@ -57,8 +61,12 @@ window.Echo = (function (global, document, undefined) {
    * @private
    */
   var _throttle = function () {
-    clearTimeout(poll);
-    poll = setTimeout(_pollImages, throttle);
+    if (!poll) {
+      _pollImages();
+    } else {
+      clearTimeout(finalPoll);
+      finalPoll = setTimeout (_pollImages, throttle);
+    }
   };
 
   /**


### PR DESCRIPTION
Before, the default behaviour was for _pollImages to be only be called 250ms (assuming default throttle value) after you stopped scrolling. Essentially, you couldn't scroll over (or near) unloaded images and have them load in without stopping.

I modified how throttle works slightly, so now instead of calling _pollImages after you have stopped scrolling, it will now only call _pollImages immediately, and then is limited to being called every 250ms (again depending on default value there). This allows images to be loaded while you are scrolling while still ensuring you can control how often it is called.
