### PR TITLE
Query for <img> elements only

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -76,7 +76,7 @@ window.Echo = (function (global, document, undefined) {
    */
   var init = function (obj) {
 
-    var nodes = document.querySelectorAll('[data-echo]');
+    var nodes = document.querySelectorAll('img[data-echo]');
     var opts = obj || {};
     offset = parseInt(opts.offset || 0);
     throttle = parseInt(opts.throttle || 250);


### PR DESCRIPTION
While this is probably a case of micro-optimisation, [there is a performance gain of some 5%](http://jsperf.com/queryselectorall-with-attr-only-and-with-element-type) when querying for `img[data-echo]` as opposed to `[data-echo]` only.
