### PR TITLE
Add a umd wrapper for commonjs and amd support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,6 +54,12 @@ module.exports = function (grunt) {
         banner: '<%= tag.banner %>'
       }
     },
+    umd: {
+      dist: {
+        src: 'dist/<%= project.name %>.js',
+        objectToExport: 'echo'
+      }
+    },
     uglify: {
       files: {
         src: ['dist/<%= project.name %>.js'],
@@ -88,6 +94,7 @@ module.exports = function (grunt) {
   grunt.registerTask('default' , [
     'jshint',
     'concat:dist',
+    'umd:dist',
     'uglify',
     // 'connect:livereload',
     // 'open',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "Echo",
   "version": "1.5.0",
+  "main": "dist/echo.js",
   "homepage": "https://github.com/toddmotto/echo",
   "author": "Todd Motto",
   "description": "Lazy-loading with data-* attributes, offset and throttle options",
@@ -26,6 +27,7 @@
     "grunt-contrib-watch": "~0.4.4",
     "connect-livereload": "~0.2.0",
     "grunt-open": "~0.2.0",
+    "grunt-umd": "^1.7.3",
     "matchdep": "~0.1.2"
   },
   "peerDependencies": {

--- a/src/echo.js
+++ b/src/echo.js
@@ -1,4 +1,5 @@
-window.Echo = (function (global, document, undefined) {
+/* exported echo */
+var echo = (function (global, document, undefined) {
 
   'use strict';
 


### PR DESCRIPTION
So it will work with cjs bundlers like browserify and amd loaders like requirejs. Tested myself with browserify and it works great! Will need to do another grunt build but after that it can be published to npm!
