### PR TITLE
Add a main field to the package json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "type": "git",
     "url": "http://github.com/toddmotto/echo.git"
   },
+  "main": "dist/echo.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.7.1",


### PR DESCRIPTION
This lets commonjs loaders like browserify and webpack simply `require` the package. It could even be published to npm.
