### PR TITLE
Fix error when using as AMD module

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -1,6 +1,8 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(factory);
+    define(function() {
+      return factory(root)
+    });
   } else if (typeof exports === 'object') {
     module.exports = factory;
   } else {


### PR DESCRIPTION
This module currently breaks when used as an AMD module (at least in RequireJS) as the first argument passed to `factory` from `define` is a reference to `require` not `window`, and so means that `addEventListener` is unavailable. If you switch this to pass a function to define which then returns `factory` with `root` passed correctly it works OK.
