### PR TITLE
add a bower.json per bower spec, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node
 node_modules
 
+#Ide
+.idea
+
 ## OS X
 .DS_Store
 .AppleDouble

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "echojs",
+  "version": "1.7.3",
+  "homepage": "https://github.com/toddmotto/echo",
+  "authors": [
+    "@toddmotto"
+  ],
+  "description": "Lazy-loading with data-* attributes, offset and throttle options",
+  "main": "src/echo.js",
+  "moduleType": [],
+  "keywords": [
+    "echo"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Minor update to include a bower.json per bower spec file.  If this doesn't exist, the wiredep gulp plugin does not work smoothly with echo.