### PR TITLE
Fixed timing out of echo.js

### DIFF
--- a/dist/echo.js
+++ b/dist/echo.js
@@ -49,7 +49,7 @@
     var offsetVertical = opts.offsetVertical || offsetAll;
     var offsetHorizontal = opts.offsetHorizontal || offsetAll;
     var optionToInt = function (opt, fallback) {
-      return parseInt(opt || fallback, 10);
+      return parseInt(opt || fallback);
     };
     offset = {
       t: optionToInt(opts.offsetTop, offsetVertical),


### PR DESCRIPTION
parseInt(opt || fallback, 10); was defaulting the timeout of echo.js to 10 milliseconds which caused echo.js to not work on longer loading pages.

delay = optionToInt(opts.throttle, 250); will now either take the delay that the user has chosen or default to 250 milliseconds
